### PR TITLE
Switch to running make targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then reference templates as `<template>.yml@templates`.
 
 ### `job--python-test.yml`
 
-Expected scripts: `scripts/install`, `scripts/test`.
+Expected scripts: `make intall`, `make test`.
 
 Example:
 
@@ -57,7 +57,7 @@ jobs:
 
 ### `job--python-check.yml`
 
-Expected scripts: `scripts/install`, `scripts/check`.
+Expected scripts: `make install`, `make check`.
 
 Example:
 
@@ -72,7 +72,7 @@ jobs:
 
 Build docs under a Python environment.
 
-Expected scripts: `scripts/install`, `scripts/docs build`.
+Expected scripts: `make install`, `make docs`.
 
 Example:
 
@@ -89,7 +89,7 @@ Publish a Python package to PyPI.
 
 #### Assumptions
 
-- `scripts/install`, `scripts/build`, `scripts/publish` must exist.
+- `make install`, `make build`, `make publish` must exist.
 - `twine` and `wheel` must be installed.
 - `token` refers to a [PyPI API token](https://pypi.org/help/#apitoken) set via a [Python upload service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#python-package-download-service-connection) (Project settings > Service connection > New... > Python package upload). It may be provided through a variable group (Library > Variable group...), as shown below.
 
@@ -135,7 +135,7 @@ steps:
 
 ### `step--python-install.yml`
 
-Expected scripts: `scripts/install`.
+Expected scripts: `make install`.
 
 Example:
 
@@ -148,7 +148,7 @@ steps:
 
 ### `step--python-test.yml`
 
-Expected scripts: `scripts/install`, `scripts/test`.
+Expected scripts: `make install`, `make test`.
 
 Example:
 

--- a/job--python-check.yml
+++ b/job--python-check.yml
@@ -10,5 +10,5 @@ jobs:
       - template: step--python-install.yml
         parameters:
           pythonVersion: ${{ parameters.pythonVersion }}
-      - bash: scripts/check
+      - script: make check
         displayName: "Run checks"

--- a/job--python-docs-build.yml
+++ b/job--python-docs-build.yml
@@ -10,5 +10,5 @@ jobs:
       - template: step--python-install.yml
         parameters:
           pythonVersion: ${{ parameters.pythonVersion }}
-      - bash: scripts/docs build
+      - script: make docs
         displayName: "Build docs"

--- a/job--python-publish.yml
+++ b/job--python-publish.yml
@@ -14,9 +14,9 @@ jobs:
       - template: step--python-install.yml
         parameters:
           pythonVersion: $(pythonVersion)
-      - bash: scripts/build
+      - script: make build
         displayName: "Build package"
-      - bash: scripts/publish
+      - script: make publish
         env:
           GIT_REF: $(Build.SourceBranch)
           TWINE_USERNAME: __token__

--- a/step--python-install.yml
+++ b/step--python-install.yml
@@ -17,5 +17,5 @@ steps:
       path: $(PIP_CACHE_DIR)
     displayName: "Cache pip dependencies"
 
-  - bash: scripts/install
+  - script: make install
     displayName: "Install dependencies"

--- a/step--python-test.yml
+++ b/step--python-test.yml
@@ -9,7 +9,7 @@ steps:
   - template: step--python-install.yml
     parameters:
       pythonVersion: ${{ parameters.pythonVersion }}
-  - bash: scripts/test
+  - script: make test
     displayName: "Run tests"
   - script: |
       pip install coverage  # Auto-convert `.coverage` to XML.


### PR DESCRIPTION
My projects increasingly use a `Makefile` rather than a directory of `scripts/`. Tentatively switching CI templates to use that as well...

Will start with refactoring https://github.com/florimondmanca/www with this, then one of the ASGI packages, such as https://github.com/florimondmanca/msgpack-asgi.